### PR TITLE
Fix urllib3 +security version parsing in check_compatibility (2.27.1+security.3)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,17 @@ dev
 
 - \[Short description of non-trivial change.\]
 
+2.27.1+security.3 (2026-06-12)
+-------------------------------
+
+**Bugfix**
+
+- `check_compatibility()` no longer fails when urllib3 reports a PEP 440
+  local version such as the ActiveState `1.26.20+security.2` build. The
+  `+security.N` segment is now stripped before parsing, so the version no
+  longer splits into `['1', '26', '20+security', '2']` (which broke the
+  major/minor/patch unpack and the `int()` conversion). Python 2 compatible.
+
 2.27.1+security.2 (2026-05-28)
 -------------------------------
 

--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -55,7 +55,11 @@ except ImportError:
     chardet_version = None
 
 def check_compatibility(urllib3_version, chardet_version, charset_normalizer_version):
-    urllib3_version = urllib3_version.split('.')
+    # Drop any PEP 440 local-version segment (e.g. the ActiveState '+security.N'
+    # tag) before parsing: '1.26.20+security.2' would otherwise split into
+    # ['1', '26', '20+security', '2'], breaking the major/minor/patch unpack and
+    # the int(patch) conversion.
+    urllib3_version = urllib3_version.split('+', 1)[0].split('.')
     assert urllib3_version != ['dev']  # Verify urllib3 isn't installed from git.
 
     # Sometimes, urllib3 only reports its version as 16.1.

--- a/requests/__version__.py
+++ b/requests/__version__.py
@@ -5,7 +5,7 @@
 __title__ = 'requests'
 __description__ = 'Python HTTP for Humans.'
 __url__ = 'https://requests.readthedocs.io'
-__version__ = '2.27.1+security.2'
+__version__ = '2.27.1+security.3'
 __build__ = 0x022701
 __author__ = 'Kenneth Reitz'
 __author_email__ = 'me@kennethreitz.org'


### PR DESCRIPTION
## Fix `check_compatibility()` for urllib3's `+security` version

Our urllib3 AS build now reports a PEP 440 **local version**, `1.26.20+security.2`. `requests.check_compatibility()` did:

```python
urllib3_version = urllib3_version.split('.')
...
major, minor, patch = urllib3_version
major, minor, patch = int(major), int(minor), int(patch)
```

`'1.26.20+security.2'.split('.')` → `['1', '26', '20+security', '2']` (4 elements), which breaks the 3-way unpack and the `int('20+security')` conversion — so importing `requests` raises.

### Fix
Strip the `+local` segment before splitting:

```python
urllib3_version = urllib3_version.split('+', 1)[0].split('.')
```

`'1.26.20+security.2'` → `'1.26.20'` → `['1','26','20']`. One line, **Python 2 compatible** (just `str.split`/slice/`int`), and it preserves the existing `['dev']` guard and the `16.1` → `16.1.0` two-component case.

### Verification (Python 2.7)
`1.26.20+security.2` → `(1, 26, 20)` (asserts pass); `1.26.20`, `1.26.0`, `1.21.1`, `1.26` parse as before; `dev` still rejected. Changed files byte-compile on 2.7.

Bundled as release **2.27.1+security.3** (`__version__` bumped, HISTORY.md entry; tag stays 4-component `2.27.1.3` per convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
